### PR TITLE
reuse existing cards when setting the whiteboard status

### DIFF
--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -484,19 +484,25 @@ sub sync_bug {
 
         my $found_cardid = find_card_for_bugid($bug->{id});
         if ( defined $found_cardid ) {
-            $log->warn("Bug $bug->{id} already has a card $found_cardid");
+            $card = retrieve_card($found_cardid, $bug->{id});
+
+            $log->warn("Bug $bug->{id} already has a card $found_cardid, updating whiteboard");
+
+            update_whiteboard($bug->{id}, $found_cardid, $whiteboard);
+
+            push @changes, "[bug updated]";
+        } else {
+            $card = create_card($bug);
+
+            if ( not $card ) {
+                $log->warn("Failed to create card for bug $bug->{id}");
+                return;
+            }
+
+            update_whiteboard( $bug->{id}, $card->{taskid}, $whiteboard );
+
+            push @changes, "[card created]";
         }
-
-        $card = create_card($bug);
-
-        if ( not $card ) {
-            $log->warn("Failed to create card for bug $bug->{id}");
-            return;
-        }
-
-        update_whiteboard( $bug->{id}, $card->{taskid}, $whiteboard );
-
-        push @changes, "[card created]";
     }
 
     my $new_card = retrieve_card( $card->{taskid}, $bug->{id} );

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -146,6 +146,19 @@ sub find_mislinked_bugs {
     }
 }
 
+sub find_card_for_bugid {
+    my($bugid) = @_;
+
+    for my $cardid (sort { $a <=> $b } keys %{ $all_cards }) {
+        my $extlink = $all_cards->{$cardid}->{extlink};
+        if (defined($extlink) && $extlink =~ /show_bug.cgi.*id=$bugid$/) {
+            return $cardid;
+        }
+    }
+
+    return undef;
+}
+
 sub find_mislinked_cards {
     # whiteboard link -> [ bug, bug, ... ]
     my %extlinks = ();
@@ -467,6 +480,11 @@ sub sync_bug {
             # This is a bug that came from a card but without a matching whiteboard...
             $log->warn("Bug $bug->{id} came from a card, but whiteboard is empty");
             return;
+        }
+
+        my $found_cardid = find_card_for_bugid($bug->{id});
+        if ( defined $found_cardid ) {
+            $log->warn("Bug $bug->{id} already has a card $found_cardid");
         }
 
         $card = create_card($bug);


### PR DESCRIPTION
When a bug's whiteboard status is cleared and we've asked the script to fix up the whiteboard, rather than assuming we need to create a new card, link to the existing card when one exists.

The script numerically sorts the cards so that we always link to the first card, when multiple cards reference a given bug, so that we aren't at risk of churning bug numbers when duplicates exist.