### PR TITLE
lower the logging level of kanbanid conversion to None

### DIFF
--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -1220,7 +1220,7 @@ sub bugmail_to_kanbanid {
   else {
     $kanbanid = 'None';
 
-    $log->warn("Unable to convert bugmail $bugmail to a valid kanbanid, resorting to 'None'.");
+    $log->debug("Unable to convert bugmail $bugmail to a valid kanbanid, resorting to 'None'.");
   }
 
   return $kanbanid;


### PR DESCRIPTION
Technically, we could warn about this constantly, but this is really only ever a problem once for each non-@mozilla.com user, and that will be apparent when they get tagged None in kanban. So, lower it to debug, so we can find it someday if needed, but otherwise stop complaining in the 5-minute logs.