### PR TITLE
implement support for two-way resolution syncing

### DIFF
--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -308,16 +308,38 @@ sub get_bug_history_latest {
     return $timestamps[-1];
 }
 
+sub refresh_card {
+    my($card) = @_;
+
+    # We'll need the cardid to refresh this.
+    my($cardid) = $card->{taskid};
+
+    # Remove this card from the cache.
+    delete ${ $all_cards }{$cardid};
+
+    # Re-fetch the card.
+    return retrieve_card($cardid, 0);
+}
+
+sub get_card_history {
+    my($card) = @_;
+
+    # Ensure that we've fetched the history for this card, if it isn't already cached.
+    unless (exists $card->{'historydetails'}) {
+        # The cache is populated by get_all_tasks, which doesn't have access to history data.
+        # So we need to clear the cache and re-fetch the card, to get its history.
+        $card = refresh_card($card);
+    }
+
+    return $card;
+}
+
 sub get_card_history_latest {
     my($card, $bugid) = @_;
 
+    $card = get_card_history($card);
+
     my $cardid = $card->{'taskid'};
-
-    # The cache is populated by get_all_tasks, which doesn't have access to history data.
-    # So we need to clear the cache and re-fetch the card, to get its history.
-    delete ${ $all_cards }{$cardid};
-
-    $card = retrieve_card($cardid, $bugid);
 
     my $history = $card->{'historydetails'};
 

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -664,10 +664,6 @@ sub retrieve_card {
     return $all_cards->{$card_id};
 }
 
-sub sync_bugzilla {
-
-}
-
 sub sync_card {
     my ( $card, $bug ) = @_;
 

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -206,7 +206,7 @@ sub find_mislinked_bugs {
 }
 
 sub find_card_for_bugid {
-    my($bugid) = @_;
+    my($bugid, $skip_archived) = @_;
 
     my $bug = $bugs{$bugid};
 
@@ -218,17 +218,23 @@ sub find_card_for_bugid {
         my $extlink = $card->{extlink};
         if (defined($extlink) && $extlink =~ /show_bug.cgi.*id=$bugid$/) {
             if ($card->{columnname} eq 'Archive') {
-                # Keep the oldest archived card we find, just in case.
+                # Record the oldest archived card we find, but keep searching.
                 $found_archived ||= $card;
             } else {
+                # We found a non-archived card. Return it, since that's great.
                 return $cardid;
             }
         }
     }
 
-    # If we reached this point, either we found an archived card, or we didn't
-    # find any cards at all. Return that result, as either a card or as undef.
-    return $found_archived;
+    # If we reached this point, either we found no cards or an archived card.
+    if ($skip_archived) {
+        # We aren't supposed to return any archived cards we found, so return undef.
+        return undef;
+    } else {
+        # We return either the first archived card we found, or undef if none found.
+        return $found_archived;
+    }
 }
 
 sub find_mislinked_cards {

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -223,6 +223,7 @@ sub find_mislinked_cards {
     my %extlinks = ();
 
     while ( my( $cardid, $card ) = each %{ $all_cards } ) {
+        next if $card->{columnname} eq 'Archive';
         my $extlink = $card->{extlink};
         if (defined($extlink) && $extlink =~ /show_bug.cgi.*id=(\d+)$/) {
             $extlinks{$1} ||= [];

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -335,7 +335,7 @@ sub get_card_history {
 }
 
 sub get_card_history_latest {
-    my($card, $bugid) = @_;
+    my($card) = @_;
 
     $card = get_card_history($card);
 
@@ -737,7 +737,7 @@ sub sync_card {
     if ($assignee_task eq 'update') {
         # Find out when the card and the bug were last updated.
         my $time_bug = get_bug_history_latest($bug->{id}, 'assigned_to');
-        my $time_card = get_card_history_latest($card, $bug->{id});
+        my $time_card = get_card_history_latest($card);
 
         if ($time_bug eq $time_card) {
             # This is incredibly unlikely to occur, but if it does, we'll assume the bug is correct.

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -796,6 +796,14 @@ sub sync_card {
         push @updated, "Updated card summary ('$bug_summary' vs '$card_summary')";
     }
 
+    # Check extlink
+    my $bug_link = "https://bugzilla.mozilla.org/show_bug.cgi?id=$bug->{id}";
+
+    if ( $card->{extlink} ne $bug_link ) {
+        update_card_extlink( $card, $bug_link );
+        push @updated, "Updated external link to bugzilla ( $card->{extlink} => $bug_link)";
+    }
+
     # Check status
     my $bug_status  = $bug->{status};
     my $card_status = $card->{columnname};
@@ -900,13 +908,7 @@ sub sync_card {
         }
     }
 
-    # Check extlink
-    my $bug_link = "https://bugzilla.mozilla.org/show_bug.cgi?id=$bug->{id}";
 
-    if ( $card->{extlink} ne $bug_link ) {
-        update_card_extlink( $card, $bug_link );
-        push @updated, "Updated external link to bugzilla ( $card->{extlink} => $bug_link)";
-    }
 
     return @updated;
 }

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -802,7 +802,7 @@ sub sync_card {
         }
         else {
             # If it's in webops, close it, otherwise, skip it ?
-            $log->warn("Bug $bug->{id} is not RESOLVED ($bug_status) but card $card->{taskid} says $card_status");
+            $log->warn("[notimplemented] Bug $bug->{id} is not RESOLVED ($bug_status) but card $card->{taskid} says $card_status");
         }
     }
 

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -208,14 +208,27 @@ sub find_mislinked_bugs {
 sub find_card_for_bugid {
     my($bugid) = @_;
 
+    my $bug = $bugs{$bugid};
+
+    # If we find an archived card, store it in case we can't find any other card.
+    my $found_archived;
+
     for my $cardid (sort { $a <=> $b } keys %{ $all_cards }) {
-        my $extlink = $all_cards->{$cardid}->{extlink};
+        my $card = $all_cards->{$cardid};
+        my $extlink = $card->{extlink};
         if (defined($extlink) && $extlink =~ /show_bug.cgi.*id=$bugid$/) {
-            return $cardid;
+            if ($card->{columnname} eq 'Archive') {
+                # Keep the oldest archived card we find, just in case.
+                $found_archived ||= $card;
+            } else {
+                return $cardid;
+            }
         }
     }
 
-    return undef;
+    # If we reached this point, either we found an archived card, or we didn't
+    # find any cards at all. Return that result, as either a card or as undef.
+    return $found_archived;
 }
 
 sub find_mislinked_cards {

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -48,6 +48,7 @@ sub version {
 #XXX: Wrong, need to be instance variables
 
 my $all_cards;
+my %bugs;
 
 my $APIKEY;
 my $BOARD_ID;
@@ -92,8 +93,6 @@ sub run {
     $ua->timeout(15);
     $ua->env_proxy;
     $ua->default_header( 'apikey' => $APIKEY );
-
-    my %bugs;
 
     if (@ARGV) {
         # fill_missing_bugs_info() needs to know the sourceid of each bugid.

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -335,7 +335,7 @@ sub load_card_history {
 }
 
 sub get_card_history_latest {
-    my($card, $field) = @_;
+    my($card, $field, $details) = @_;
 
     $card = load_card_history($card);
 
@@ -347,6 +347,9 @@ sub get_card_history_latest {
 
     for my $change (@{ $history }) {
         next unless $change->{'historyevent'} =~ /$field/i;
+        if (defined($details)) {
+            next unless $change->{'details'} =~ /$details/;
+        }
         my $entrydate = $change->{'entrydate'};
         $entrydate =~ s/^(....-..-..) (..:..:..)$/$1T$2Z/;
         die "Unable to post-process entrydate from kanbanize" unless $entrydate =~ /^....-..-..T..:..:..Z$/;

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -370,7 +370,7 @@ sub get_bugs {
     my $uri = URI->new("https://bugzilla.mozilla.org/rest/bug");
 
     $uri->query_param(token => $BUGZILLA_TOKEN);
-    $uri->query_param(include_fields => qw(id status whiteboard summary assigned_to));
+    $uri->query_param(include_fields => qw(id status whiteboard summary assigned_to creation_time));
     $uri->query_param(bug_status => qw(NEW UNCONFIRMED REOPENED ASSIGNED));
     $uri->query_param(product => @PRODUCTS);
     $uri->query_param(component => @COMPONENTS);

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -321,7 +321,7 @@ sub refresh_card {
     return retrieve_card($cardid, 0);
 }
 
-sub get_card_history {
+sub load_card_history {
     my($card) = @_;
 
     # Ensure that we've fetched the history for this card, if it isn't already cached.
@@ -337,7 +337,7 @@ sub get_card_history {
 sub get_card_history_latest {
     my($card, $field) = @_;
 
-    $card = get_card_history($card);
+    $card = load_card_history($card);
 
     my $cardid = $card->{'taskid'};
 

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -335,7 +335,7 @@ sub get_card_history {
 }
 
 sub get_card_history_latest {
-    my($card) = @_;
+    my($card, $field) = @_;
 
     $card = get_card_history($card);
 
@@ -346,7 +346,7 @@ sub get_card_history_latest {
     my @timestamps = ();
 
     for my $change (@{ $history }) {
-        next unless $change->{'historyevent'} =~ /assignee/i;
+        next unless $change->{'historyevent'} =~ /$field/i;
         my $entrydate = $change->{'entrydate'};
         $entrydate =~ s/^(....-..-..) (..:..:..)$/$1T$2Z/;
         die "Unable to post-process entrydate from kanbanize" unless $entrydate =~ /^....-..-..T..:..:..Z$/;
@@ -657,7 +657,6 @@ sub retrieve_card {
 
     my $params = {
         history => "yes",
-        event   => "update",
     };
 
     my $req =
@@ -737,7 +736,7 @@ sub sync_card {
     if ($assignee_task eq 'update') {
         # Find out when the card and the bug were last updated.
         my $time_bug = get_bug_history_latest($bug->{id}, 'assigned_to');
-        my $time_card = get_card_history_latest($card);
+        my $time_card = get_card_history_latest($card, 'assignee');
 
         if ($time_bug eq $time_card) {
             # This is incredibly unlikely to occur, but if it does, we'll assume the bug is correct.


### PR DESCRIPTION
This changeset implements two-way syncing of closed/open status between bugs/cards.

If you close a bug, the card will be closed. If you reopen a bug, the card will be opened (or, if it's archived, a new card will be created).

If you close a card, the bug will be resolved. If you reopen a card (or, somehow, create a new card referencing the resolved bug), the bug will be reopened.

Fixes #6.