### PR TITLE
Repair bugs that point to another bug's card.

### DIFF
--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -656,11 +656,15 @@ sub sync_bug {
 
     $card = $new_card;
 
+    # Assuming we didn't just create a new card, we need to sync the existing card to match the bug.
+    if (@changes > 0 && $changes[-1] !~ /card created/) {
+
+        #$log->debug("Syncing card $card->{taskid} extlink << $card->{extlink} >> with bug $bug->{id} whiteboard << $bug->{whiteboard} >>") if $config->verbose;
+
+        push @changes, sync_card( $card, $bug );
+    }
+
     my $cardid = $card->{taskid};
-
-    #$log->debug("Syncing card $card->{taskid} extlink << $card->{extlink} >> with bug $bug->{id} whiteboard << $bug->{whiteboard} >>") if $config->verbose;
-
-    push @changes, sync_card( $card, $bug );
 
     if ( $config->verbose ) {
         $log->debug(sprintf "[%4d/%4d] Card %4d - Bug %8d - [%s] %s ** %s **",

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -1060,6 +1060,8 @@ sub update_card_extlink {
 
     $req->content( encode_json($data) );
 
+    $log->debug("Updating card $taskid extlink to << $extlink >>") if $config->verbose;
+
     my $res = $ua->request($req);
 
     if ( !$res->is_success ) {
@@ -1228,6 +1230,8 @@ sub update_card_summary {
 
     $req->content( encode_json($data) );
 
+    $log->debug("Updating card $taskid summary to << $bug_summary >>") if $config->verbose;
+
     my $res = $ua->request($req);
 
     if ( !$res->is_success ) {
@@ -1255,6 +1259,8 @@ sub update_card_assigned {
       );
 
     $req->content("[]");
+
+    $log->debug("Updating card $card->{taskid} assignee to << $assignee >>") if $config->verbose;
 
     my $res = $ua->request($req);
 
@@ -1305,6 +1311,8 @@ sub update_whiteboard {
     $whiteboard =~ s/\s+$//;
 
     $req->content("whiteboard=$whiteboard&token=$BUGZILLA_TOKEN");
+
+    $log->debug("Updating whiteboard for bug $bugid to << $whiteboard >>") if $config->verbose;
 
     my $res = $ua->request($req);
 


### PR DESCRIPTION
First, improve debugging under verbose. This was necessary to trace issue #27.

Next, only sync cards when we didn't just create a new one, since in that circumstance it's a waste of time to proceed further.

Finally, identify when a bug's whiteboard status references a card whose extlink references a different bug. Resolve this by updating the whiteboard to point to either an existing non-archived card for the bug, or to a new card created for it.

Closes #27.