### PR TITLE
Permit new cards to be opened as Low priority.

### DIFF
--- a/bin/kanbanize-bugzilla-sync
+++ b/bin/kanbanize-bugzilla-sync
@@ -19,6 +19,7 @@ my $config = AppConfig->new(
     "kanbanize_apikey=s",
     "kanbanize_boardid=i",
     "kanbanize_incoming=s",
+    "kanbanize_priority=s",
     "bugzilla_token=s",
     "bugzilla_id=s",
     "component=s@",

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -1405,9 +1405,9 @@ sub create_card {
     }
 
     my $data = {
-        'title'   => api_encode_title("$bug->{id} - $bug->{summary}"),
-        'extlink' => "https://bugzilla.mozilla.org/show_bug.cgi?id=$bug->{id}",
-        'boardid' => $BOARD_ID,
+        'title'    => api_encode_title("$bug->{id} - $bug->{summary}"),
+        'extlink'  => "https://bugzilla.mozilla.org/show_bug.cgi?id=$bug->{id}",
+        'boardid'  => $BOARD_ID,
         'priority' => $KANBANIZE_PRIORITY,
     };
 

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -54,6 +54,7 @@ my $APIKEY;
 my $BOARD_ID;
 my $BUGZILLA_TOKEN;
 my $KANBANIZE_INCOMING;
+my $KANBANIZE_PRIORITY;
 my $WHITEBOARD_TAG;
 my @COMPONENTS;
 my @PRODUCTS;
@@ -81,6 +82,7 @@ sub run {
       or die "Please configure a bugzilla_token";
 
     $KANBANIZE_INCOMING = $config->kanbanize_incoming;
+    $KANBANIZE_PRIORITY = $config->kanbanize_priority || "Average";
 
     $WHITEBOARD_TAG = $config->tag || die "Missing whiteboard tag";
 
@@ -1406,6 +1408,7 @@ sub create_card {
         'title'   => api_encode_title("$bug->{id} - $bug->{summary}"),
         'extlink' => "https://bugzilla.mozilla.org/show_bug.cgi?id=$bug->{id}",
         'boardid' => $BOARD_ID,
+        'priority' => $KANBANIZE_PRIORITY,
     };
 
     my $req =

--- a/sync-dist.cfg
+++ b/sync-dist.cfg
@@ -2,6 +2,7 @@
 kanbanize_apikey=
 kanbanize_boardid=
 kanbanize_incoming="Pending Triage"
+kanbanize_priority="Average"
 
 # The API key must be associated with a user whose timezone is UTC.
 # Otherwise, syncing-related time comparisons with Bugzilla will fail.


### PR DESCRIPTION
This pull request implements a configurable priority for newly-created cards that are filed into the "Pending Triage" location. We'd like to use Low rather than Average, which would be done solely through the config.