### PR TITLE
HTTP to HTTPS; Handle archived/reopened cards more appropriately.

### DIFF
--- a/bin/kanbanize-bugzilla-sync
+++ b/bin/kanbanize-bugzilla-sync
@@ -28,7 +28,7 @@ my $config = AppConfig->new(
     "mail-map_bugmail=%",
     
     # "bugzilla_url=s", { DEFAULT => "https://bugzilla.mozilla.org" },
-    # "kanbanize_url=s", { DEFAULT => "http://kanbanize.com" },
+    # "kanbanize_url=s", { DEFAULT => "https://kanbanize.com" },
 );
 
 $config->file("sync.cfg") if -r "sync.cfg";

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -541,7 +541,7 @@ sub get_bugs_from_all_cards {
 
     my $req =
       HTTP::Request->new( POST =>
-"http://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/get_all_tasks/boardid/$BOARD_ID/format/json"
+"https://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/get_all_tasks/boardid/$BOARD_ID/format/json"
       );
 
     $req->header( "Content-Length" => "0" );
@@ -733,7 +733,7 @@ sub retrieve_card {
 
     my $req =
       HTTP::Request->new( POST =>
-"http://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/get_task_details/boardid/$BOARD_ID/taskid/$card_id/format/json"
+"https://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/get_task_details/boardid/$BOARD_ID/taskid/$card_id/format/json"
       );
 
     $req->content( encode_json($params) );
@@ -1042,7 +1042,7 @@ sub unblock_card {
 
     my $req =
       HTTP::Request->new( POST =>
-          "http://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/block_task/format/json"
+          "https://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/block_task/format/json"
       );
 
     $req->content( encode_json($data) );
@@ -1079,7 +1079,7 @@ sub complete_card {
 
     my $req =
       HTTP::Request->new( POST =>
-          "http://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/move_task/format/json"
+          "https://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/move_task/format/json"
       );
 
     $req->content( encode_json($data) );
@@ -1111,7 +1111,7 @@ sub update_card_extlink {
 
     my $req =
       HTTP::Request->new( POST =>
-          "http://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/edit_task/format/json"
+          "https://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/edit_task/format/json"
       );
 
     $req->content( encode_json($data) );
@@ -1281,7 +1281,7 @@ sub update_card_summary {
 
     my $req =
       HTTP::Request->new( POST =>
-          "http://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/edit_task/format/json"
+          "https://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/edit_task/format/json"
       );
 
     $req->content( encode_json($data) );
@@ -1311,7 +1311,7 @@ sub update_card_assigned {
 
     my $req =
       HTTP::Request->new( POST =>
-"http://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/edit_task/format/json/boardid/$BOARD_ID/taskid/$taskid/assignee/$assignee"
+"https://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/edit_task/format/json/boardid/$BOARD_ID/taskid/$taskid/assignee/$assignee"
       );
 
     $req->content("[]");
@@ -1421,7 +1421,7 @@ sub create_card {
 
     my $req =
       HTTP::Request->new( POST =>
-"http://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/create_new_task/format/json"
+"https://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/create_new_task/format/json"
       );
 
     $req->content( encode_json($data) );
@@ -1460,7 +1460,7 @@ sub move_card {
 
     my $req =
       HTTP::Request->new( POST =>
-          "http://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/move_task/format/json"
+          "https://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/move_task/format/json"
       );
 
     $req->content( encode_json($data) );

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -707,6 +707,20 @@ sub sync_bug {
 
             push @changes, "[card created]";
         }
+    } elsif (is_archived_card($card)) {
+        # This bug references an archived card, so open a new card.
+        $log->warn("Bug $bug->{id} whiteboard << $whiteboard >> references an archived card, creating a new card");
+
+        $card = create_card($bug);
+
+        if ( not $card ) {
+            $log->warn("Failed to create card for bug $bug->{id}");
+            return;
+        }
+
+        update_whiteboard( $bug->{id}, $card->{taskid}, $whiteboard );
+
+        push @changes, "[card created]";
     }
 
     # Assuming we didn't just create a new card, we need to sync the existing card to match the bug.

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -216,7 +216,7 @@ sub is_archived_card {
     } elsif (defined($check_history) && $check_history) {
         # Loading the card history takes an extra API call.
         load_card_history($card);
-        if (eval { $card->{historydetails}[0]{historyevent} eq 'Task archived' }) {
+        if (eval { no warnings 'uninitialized'; $card->{historydetails}[0]{historyevent} eq 'Task archived' }) {
             # This is a permanently-archived card.
             return 1;
         }
@@ -386,6 +386,7 @@ sub get_card_history_latest {
     my @timestamps = ();
 
     for my $change (@{ $history }) {
+        next unless exists $change->{'historyevent'};
         next unless $change->{'historyevent'} =~ /$field/i;
         if (defined($details)) {
             next unless $change->{'details'} =~ /$details/;


### PR DESCRIPTION
3c216fa changes all http:// to https:// URLs, which somehow had not been found and fixed yet.

f093073 detects archived cards during ```sync_bug()```, when the bug and card *do* actually match, because otherwise we started trying to alter properties of the archived card.