### PR TITLE
Detect and log bad extlink strings in cards

### DIFF
--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -679,8 +679,10 @@ sub sync_bug {
     $card = $new_card;
 
     # Check the card extlink, if one is present, and make sure that it references the correct bug.
-    my($referenced_bug) = ($card->{extlink} =~ /show_bug.cgi.*id=(\d+)$/);
-    if (defined($referenced_bug) && $referenced_bug ne $bug->{id}) {
+    my($referenced_bug) = ($card->{extlink} =~ /show_bug.cgi.*[&?]id=(\d+)/);
+    if (!defined($referenced_bug)) {
+        $log->warn("Bug $bug->{id} references card $card->{taskid}, but the card does not point back to a properly formatted bug.");
+    } elsif ($referenced_bug ne $bug->{id}) {
         $log->warn("Bug $bug->{id} references card $card->{taskid} which references bug $referenced_bug, assigning bug $bug->{id} a new card.");
 
         my $found_cardid = find_card_for_bugid($bug->{id});


### PR DESCRIPTION
If a card's extlink is not perfectly defined, you could have a regex fail to match.  If it fails to match, there's nothing to intercept it in later checks within sync_bug.

While nothing in particular would care about it, this logging breaks up a logical oddity, in that you don't know whether you skipped a block of code because you got no match on extlink (a somewhat undesirable situation) or because it exactly matched the bugid (a desirable situation).