### PR TITLE
Only spin a new card if not-closed bugs point at an archived card

### DIFF
--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -708,8 +708,8 @@ sub sync_bug {
 
             push @changes, "[card created]";
         }
-    } elsif (is_archived_card($card)) {
-        # This bug references an archived card, so open a new card.
+    } elsif (is_archived_card($card) && ($bug->{status} !~ /^(RESOLVED|VERIFIED)$/)) {
+        # If the bug is open, and references an archived card, open a new card.
         $log->warn("Bug $bug->{id} whiteboard << $whiteboard >> references an archived card, creating a new card");
 
         $card = create_card($bug);


### PR DESCRIPTION
When a card is archived, this can change the timing such that a card is more recently closed than a bug, leading to notice that the bug is pointing at an archived card and triggering a new card.
If a bug is in a terminal state and the card is archived, there's no need to open a new card.  Only open a new card in the case where a live bug (probably REOPENED but don't assume that) has come alive and points at an archived card.